### PR TITLE
feat: adds two typescript plugins

### DIFF
--- a/lua/plugins/languages/typescript.lua
+++ b/lua/plugins/languages/typescript.lua
@@ -1,0 +1,12 @@
+return {
+  {
+    "dmmulroy/tsc.nvim",
+    opts = {},
+    cmd = "TSC",
+  },
+  {
+    "dmmulroy/ts-error-translator.nvim",
+    opts = {},
+    ft = "typescript",
+  },
+}


### PR DESCRIPTION
Adds support for plugin with a built-in project builder that gives project wide typescript errors. The second plug in is a replica of the VS Code better typescript errors plugin.