### PR TITLE
feat(keybindings): add option backspace mapping to ctrl w in warp

### DIFF
--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -65,3 +65,6 @@ map("n", "Ú" --[[ Option + Shift + ; ]], lazyterm, { desc = "Terminal (root dir
 map("t", "Ú" --[[ Option + Shift + ; ]], "<cmd>close<cr>", { desc = "Hide Terminal" })
 map("n", "<C-;>", lazyterm, { desc = "Terminal (root dir)" })
 map("t", "<C-;>", "<cmd>close<cr>", { desc = "Hide Terminal" })
+
+-- mapping to allow option backspace to act as ctrl w
+vim.keymap.set("i", "<m-bs>", "<c-w>", { noremap = true, silent = true })

--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -15,7 +15,7 @@ vim.opt.mousescroll = "ver:1,hor:6" -- Default: "ver:3,hor:6"
 vim.opt.wrap = true
 vim.opt.linebreak = true
 vim.opt.breakindent = true
-
+vim.keymap.set("i", "<m-bs>", "<c-w>", { noremap = true, silent = true })
 vim.g.root_spec = { { ".git", "lua" }, "lsp", "cwd" }
 
 vim.filetype.add({

--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -15,7 +15,6 @@ vim.opt.mousescroll = "ver:1,hor:6" -- Default: "ver:3,hor:6"
 vim.opt.wrap = true
 vim.opt.linebreak = true
 vim.opt.breakindent = true
-vim.keymap.set("i", "<m-bs>", "<c-w>", { noremap = true, silent = true })
 vim.g.root_spec = { { ".git", "lua" }, "lsp", "cwd" }
 
 vim.filetype.add({


### PR DESCRIPTION
This config option uses the meta key and requires this setting to be on in warp
![image](https://github.com/user-attachments/assets/9b88aa4b-95a2-45f4-a9fb-7ba1c520ef1f)
Similar settings exist in other terminals